### PR TITLE
Upgrade to alpine 3.21.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,28 +1,22 @@
 kind: pipeline
 type: docker
-name: httpd-image-build
+name: httpd-amd64
 
-# Trigger conditions
 trigger:
   branch:
     - '2.4'
-    - main
   event:
-    - custom
-    - push
     - pull_request
 
-# Pipeline steps
+# Build the docker image for amd64 architecture
 steps:
-  # Build image
-  - name: docker-build
+  - name: httpd-image-build-amd64
     image: plugins/docker
-    when:
-      branch:
-        - '2.4'
-      event:
-        - push
+    environment:
+      DOCKER_BUILDKIT: 1
     settings:
+      platforms:
+        - linux/amd64
       username:
         from_secret: docker_username
       password:
@@ -30,11 +24,52 @@ steps:
       repo: kernel528/httpd
       tags:
         - latest
-        - 2.4.62
-        - 2.4.62-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}
+        - '2.4'
+        - '2.4-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '2.4.62'
+        - '2.4.62-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
-  # Test image
-  - name: docker-test
+  # Slack notification
+  - name: slack-notification
+    image: plugins/slack
+    when:
+      status:
+        - failure
+        - success
+    settings:
+      webhook:
+        from_secret: slack_webhook_drone_alerts
+---
+
+kind: pipeline
+type: docker
+name: main-httpd-amd64
+
+trigger:
+  event:
+    - push
+    - tag
+  branch:
+    - main
+
+# Build the docker image for the main branch & tagged release
+steps:
+  - name: main-docker-image-build
+    image: plugins/docker
+    when:
+      event:
+        - tag
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: kernel528/httpd
+      tags:
+        - ${DRONE_TAG}
+
+  # Test docker image
+  - name: latest-httpd-amd64-test
     image: kernel528/httpd:latest
     when:
       branch:
@@ -43,15 +78,15 @@ steps:
         - push
     commands:
       - cat /etc/alpine-release
-      - "httpd -v"
+      - httpd -v
 
   # Slack notification
-  - name: notify
+  - name: slack-notification
     image: plugins/slack
-    settings:
-      webhook:
-        from_secret: slack_webhook_drone_alerts
     when:
       status:
         - failure
         - success
+    settings:
+      webhook:
+        from_secret: slack_webhook_drone_alerts

--- a/.drone.yml.backup
+++ b/.drone.yml.backup
@@ -1,0 +1,57 @@
+kind: pipeline
+type: docker
+name: httpd-image-build
+
+# Trigger conditions
+trigger:
+  branch:
+    - '2.4'
+    - main
+  event:
+    - custom
+    - push
+    - pull_request
+
+# Pipeline steps
+steps:
+  # Build image
+  - name: docker-build
+    image: plugins/docker
+    when:
+      branch:
+        - '2.4'
+      event:
+        - push
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: kernel528/httpd
+      tags:
+        - latest
+        - 2.4.62
+        - 2.4.62-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}
+
+  # Test image
+  - name: docker-test
+    image: kernel528/httpd:latest
+    when:
+      branch:
+        - main
+      event:
+        - push
+    commands:
+      - cat /etc/alpine-release
+      - "httpd -v"
+
+  # Slack notification
+  - name: notify
+    image: plugins/slack
+    settings:
+      webhook:
+        from_secret: slack_webhook_drone_alerts
+    when:
+      status:
+        - failure
+        - success

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Based on https://github.com/docker-library/httpd/blob/3056c115a9f3c2467cc6f67470cfded70c4adc64/2.4/alpine/Dockerfile
-FROM kernel528/alpine:3.20.3
+FROM kernel528/alpine:3.21.0
 
 LABEL maintainer=kernel528@gmail.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM kernel528/alpine:3.21.0
 
 LABEL maintainer=kernel528@gmail.com
 
+# Set to root user to install packages
+USER root
+
 # ensure www-data user exists
 RUN set -x \
 	&& adduser -u 82 -D -S -G www-data www-data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 [![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/httpd-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/httpd-docker)
+[![Latest Version](https://img.shields.io/github/v/tag/kernel528/httpd-docker)](https://github.com/kernel528/httpd-docker/releases/latest)
+[![Docker Pulls](https://img.shields.io/docker/pulls/kernel528/httpd)](https://hub.docker.com/r/kernel528/httpd)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/httpd/2.4.62)](https://hub.docker.com/r/kernel528/httpd/2.4.62)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/kernel528/httpd?sort=semver)](https://hub.docker.com/r/kernel528/httpd)
 
 # Base Httpd Docker repo
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,25 +1,16 @@
 # Used to track the base repo version.
 * v1.0.0 - Initial commit.
-* v1.0.1 - Updated to trigger rebuild to use alpine 3.8.2 base.
-* v1.1.0 - Updated to trigger build on new drone.
-* v1.2.0 - Updated to build with new drone 1.0.0-rc5
-* v1.3.0 - Updated to use alpine 3.9.2, openjdk8-201.08-r0 and httpd v2.4.38
-* v2.0.0 - Updated to use latest alpine 3.9.2 build, changed folder struture
-* v2.0.1 - Updated to use alpine 3.9.4 and httpd 2.4.39
-* v3.0.0 - Updated to use alpine 3.10.1 and to build straight off kernel528/alpine:3.10.1
-* v4.0.0 - Updated to use alpine 3.11.6 and httpd v2.4.43
-* v4.0.1 - Updated to trigger buld with drone.
-* v4.1.0 - Updated to alpine v3.12.0
-* v4.1.1 - Another attempt to trigger drone build: 2020-06-28, 2, 3
-* v4.1.2 - Updated to httpd-2.4.46
-* v4.1.3 - Updated to alpine v3.12.2
-* v4.1.4 - Updated to alpine v3.12.3
-* v4.2.0 - Updated to alpine 3.14.0, httpd v2.4.48.  Update Dockerfile template.
-* v4.2.1 - Updated to alpine 3.14.2
-* v5.0.0 - Updated to alpine 3.15.0, httpd v2.4.52
-* v5.1.0 - Updated to alpine 3.20.1, httpd v2.4.59
-* v5.1.1 - Uses alpine 3.20.1, updated httpd to v2.4.62
-* v5.1.1a - Updated to trigger test build.
-* v5.1.1b - Updated to trigger test build.
-* v5.1.1c - Updated to alpine v3.20.3
-* v5.1.2 - Updated .drone.yml pipeline to use slack_webhook drone secret.  2024-12-01
+* v2.4.0 - Updated to trigger rebuild to use alpine 3.8.2 base. Aligned on httpd version.
+* v2.4.1 - Updated to trigger build on new drone.
+* v2.4.2 - Updated to build with new drone 1.0.0-rc5
+* v2.4.38 - Updated to use alpine 3.9.2, openjdk8-201.08-r0 and httpd v2.4.38.  Aligned on httpd version.
+* v2.4.39 - Updated to use alpine 3.9.4 and httpd 2.4.39
+* v2.4.43 - Updated to use alpine 3.11.6 and httpd v2.4.43
+* v2.4.46 - Updated to httpd-2.4.46
+* v4.4.48 - Updated to alpine 3.14.0, httpd v2.4.48.  Update Dockerfile template.
+* v2.4.52 - Updated to alpine 3.15.0, httpd v2.4.52
+* v2.4.59 - Updated to alpine 3.20.1, httpd v2.4.59
+* v2.4.62 - Uses alpine 3.20.1, updated httpd to v2.4.62
+* v2.4.62.a - Updated to alpine v3.20.3
+* v2.4.62.b - Updated .drone.yml pipeline to use slack_webhook drone secret.  2024-12-01
+* v2.4.62.c - Updated to alpine v3.21.0, httpd v2.4.62

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -13,6 +13,6 @@
 </head>
 <body>
     <h1>Welcome to the Default Homepage!</h1>
-    <p>This is currently running httpd v2.4.62, on alpine linux kernel528/alpine:3.20.3</p>
+    <p>This is currently running httpd v2.4.62, on alpine linux kernel528/alpine:3.21.0</p>
 </body>
 </html>


### PR DESCRIPTION
- Updated README.md badge links.
- Updated Dockerfile to use kernel528/alpine:3.21.0 as base image.
- Updated Dockerfile to align with upstream https://github.com/kernel528/httpd-docker/blob/main/Dockerfile updates.
- Updated VERSION.md to align with httpd versions.  
- Updated htdocs/index.html to reflect new alpine version 3.21.0 reference.  