### PR TITLE
Update httpd to 2.4.68 on Alpine 3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,10 +25,10 @@ steps:
       tags:
         - '2.4'
         - '2.4-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '2.4.66'
-        - '2.4.66-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '2.4.66-3.23.3'
-        - '2.4.66-3.23.3-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '2.4.68'
+        - '2.4.68-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '2.4.68-3.24.1'
+        - '2.4.68-3.24.1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/httpd:2.4.66-3.23.3 -f Dockerfile .
+  docker build -t kernel528/httpd:2.4.68-3.24.1 -f Dockerfile .
   ```
 - Run a container:
   ```sh
-  docker run -dit --rm --name httpd --hostname httpd -p 80:80 kernel528/httpd:2.4.66-3.23.3
+  docker run -dit --rm --name httpd --hostname httpd -p 80:80 kernel528/httpd:2.4.68-3.24.1
   ```
 - Verify version:
   ```sh
@@ -31,7 +31,7 @@
 - If adjusting config files, confirm the server starts and serves `htdocs/`.
 
 ## Commit & Pull Request Guidelines
-- Commit messages are concise and descriptive (e.g., “Updated base image to kernel528/alpine:3.23.3.”).
+- Commit messages are concise and descriptive (e.g., “Updated base image to kernel528/alpine:3.24.1.”).
 - Branch flow: version branch → `2.4` → `main`, then tag from `main`.
 - PRs should update `VERSION.md`, `README.md`, and `.drone.yml` when tags change.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Based on https://github.com/docker-library/httpd/blob/3056c115a9f3c2467cc6f67470cfded70c4adc64/2.4/alpine/Dockerfile
-FROM kernel528/alpine:3.23.3
+# Based on https://github.com/docker-library/httpd/blob/master/2.4/alpine/Dockerfile
+FROM kernel528/alpine:3.24.1
 
 LABEL maintainer=kernel528@gmail.com
 
@@ -32,8 +32,8 @@ RUN set -eux; \
 		perl \
 	;
 
-ENV HTTPD_VERSION 2.4.66
-ENV HTTPD_SHA256 94d7ff2b42acbb828e870ba29e4cbad48e558a79c623ad3596e4116efcfea25a
+ENV HTTPD_VERSION 2.4.68
+ENV HTTPD_SHA256 68c74d4df38c26bed4dfbdb8f3baf1eb532f3872357becc1bba5d136f6b63c06
 
 # https://httpd.apache.org/security/vulnerabilities_24.html
 ENV HTTPD_PATCHES=""

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/httpd-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/httpd-docker)
 [![Latest Version](https://img.shields.io/github/v/tag/kernel528/httpd-docker)](https://github.com/kernel528/httpd-docker/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kernel528/httpd)](https://hub.docker.com/r/kernel528/httpd)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/httpd/2.4.66)](https://hub.docker.com/r/kernel528/httpd/2.4.66)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/httpd/2.4.68)](https://hub.docker.com/r/kernel528/httpd/2.4.68)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/kernel528/httpd?sort=semver)](https://hub.docker.com/r/kernel528/httpd)
 
 # Base Httpd Docker repo
@@ -15,12 +15,12 @@ These images are based on the official httpd docker hub release. The source Dock
 
 ## Build
 ```
-docker build -t kernel528/httpd:2.4.66-3.23.3 -f Dockerfile .
+docker build -t kernel528/httpd:2.4.68-3.24.1 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -dit --rm --name httpd-docker --hostname httpd-docker -p 80:80 kernel528/httpd:2.4.66-3.23.3
+docker run -dit --rm --name httpd-docker --hostname httpd-docker -p 80:80 kernel528/httpd:2.4.68-3.24.1
 ```
 ```
 Open web browser to http://localhost
@@ -34,7 +34,7 @@ COPY ./my-httpd.conf /usr/local/apache2/conf/httpd.conf
 
 ## Custom content (htdocs)
 ```
-docker run -dit --rm --name httpd --hostname httpd -p 80:80 -v "$PWD/htdocs":/usr/local/apache2/htdocs/ kernel528/httpd:2.4.66-3.23.3
+docker run -dit --rm --name httpd --hostname httpd -p 80:80 -v "$PWD/htdocs":/usr/local/apache2/htdocs/ kernel528/httpd:2.4.68-3.24.1
 ```
 
 ## Authors

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,7 +1,7 @@
 # Version History (Httpd Image)
 Notes:
 - Versions track the httpd release and the Alpine base where applicable.
-- Suffixes like `-3.23.3` indicate the `kernel528/alpine` base tag used.
+- Suffixes like `-3.24.1` indicate the `kernel528/alpine` base tag used.
 
 - v1.0.0: Initial commit.
 - v2.4.0: Trigger rebuild to use alpine 3.8.2 base; aligned on httpd version.
@@ -26,3 +26,4 @@ Notes:
 - v2.4.65-3.22.2: Updated base image to kernel528/alpine:3.22.2.
 - v2.4.66-3.23.2: Updated base image to kernel528/alpine:3.23.2 and httpd 2.4.66.
 - v2.4.66-3.23.3: Updated base image to kernel528/alpine:3.23.3.
+- v2.4.68-3.24.1: Updated base image to kernel528/alpine:3.24.1 and httpd 2.4.68.


### PR DESCRIPTION
## Summary
- update base image to kernel528/alpine:3.24.1
- update Apache HTTPD to 2.4.68
- update HTTPD source SHA256
- update Drone tags, README examples, AGENTS guidance, and VERSION history

## Upstream
- Apache HTTPD latest stable: 2.4.68
- docker-library/httpd 2.4/alpine uses HTTPD_VERSION 2.4.68 and SHA256 68c74d4df38c26bed4dfbdb8f3baf1eb532f3872357becc1bba5d136f6b63c06

## Validation
- docker image build --no-cache -t kernel528/httpd:2.4.68-3.24.1 -f Dockerfile .
- docker container run --rm kernel528/httpd:2.4.68-3.24.1 httpd -v
- docker container run --rm kernel528/httpd:2.4.68-3.24.1 cat /etc/alpine-release
- internal HTTP serving check with wget http://127.0.0.1/