### PR TITLE
Rebase HTTPD 2.4.68 on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,8 +27,8 @@ steps:
         - '2.4-drone-build-${DRONE_BUILD_NUMBER}-amd64'
         - '2.4.68'
         - '2.4.68-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '2.4.68-3.24.1'
-        - '2.4.68-3.24.1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '2.4.68-3.24.1_1'
+        - '2.4.68-3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@
 ## Build, Test, and Development Commands
 - Build locally:
   ```sh
-  docker build -t kernel528/httpd:2.4.68-3.24.1 -f Dockerfile .
+  docker build -t kernel528/httpd:2.4.68-3.24.1_1 -f Dockerfile .
   ```
 - Run a container:
   ```sh
-  docker run -dit --rm --name httpd --hostname httpd -p 80:80 kernel528/httpd:2.4.68-3.24.1
+  docker run -dit --rm --name httpd --hostname httpd -p 80:80 kernel528/httpd:2.4.68-3.24.1_1
   ```
 - Verify version:
   ```sh
@@ -31,7 +31,7 @@
 - If adjusting config files, confirm the server starts and serves `htdocs/`.
 
 ## Commit & Pull Request Guidelines
-- Commit messages are concise and descriptive (e.g., “Updated base image to kernel528/alpine:3.24.1.”).
+- Commit messages are concise and descriptive (e.g., “Updated base image to kernel528/alpine:3.24.1_1.”).
 - Branch flow: version branch → `2.4` → `main`, then tag from `main`.
 - PRs should update `VERSION.md`, `README.md`, and `.drone.yml` when tags change.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Based on https://github.com/docker-library/httpd/blob/master/2.4/alpine/Dockerfile
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 LABEL maintainer=kernel528@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ These images are based on the official httpd docker hub release. The source Dock
 
 ## Build
 ```
-docker build -t kernel528/httpd:2.4.68-3.24.1 -f Dockerfile .
+docker build -t kernel528/httpd:2.4.68-3.24.1_1 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -dit --rm --name httpd-docker --hostname httpd-docker -p 80:80 kernel528/httpd:2.4.68-3.24.1
+docker run -dit --rm --name httpd-docker --hostname httpd-docker -p 80:80 kernel528/httpd:2.4.68-3.24.1_1
 ```
 ```
 Open web browser to http://localhost
@@ -34,7 +34,7 @@ COPY ./my-httpd.conf /usr/local/apache2/conf/httpd.conf
 
 ## Custom content (htdocs)
 ```
-docker run -dit --rm --name httpd --hostname httpd -p 80:80 -v "$PWD/htdocs":/usr/local/apache2/htdocs/ kernel528/httpd:2.4.68-3.24.1
+docker run -dit --rm --name httpd --hostname httpd -p 80:80 -v "$PWD/htdocs":/usr/local/apache2/htdocs/ kernel528/httpd:2.4.68-3.24.1_1
 ```
 
 ## Authors

--- a/VERSION.md
+++ b/VERSION.md
@@ -27,3 +27,4 @@ Notes:
 - v2.4.66-3.23.2: Updated base image to kernel528/alpine:3.23.2 and httpd 2.4.66.
 - v2.4.66-3.23.3: Updated base image to kernel528/alpine:3.23.3.
 - v2.4.68-3.24.1: Updated base image to kernel528/alpine:3.24.1 and httpd 2.4.68.
+- v2.4.68-3.24.1_1: Rebuilt httpd 2.4.68 on kernel528/alpine:3.24.1_1.


### PR DESCRIPTION
## Summary
- rebase HTTPD 2.4.68 on kernel528/alpine:3.24.1_1
- update immutable image tags, Drone outputs, README, version history, and repository guidance

## Validation status
Blocked on native Linux Mint validation. The macOS arm64 host reached HTTPD source compilation under linux/amd64 emulation, then QEMU terminated GCC with a segmentation fault.

Required on Linux Mint before marking ready:

```bash
docker image build --no-cache --platform linux/amd64 -t kernel528/httpd:2.4.68-3.24.1_1 -f Dockerfile .
docker container run --rm kernel528/httpd:2.4.68-3.24.1_1 httpd -v
docker container run --rm kernel528/httpd:2.4.68-3.24.1_1 httpd -t
```

Do not merge until these commands pass.